### PR TITLE
drm/ili9163: Add "1.8-128160EF" to spi_device_id table

### DIFF
--- a/drivers/gpu/drm/tiny/ili9163.c
+++ b/drivers/gpu/drm/tiny/ili9163.c
@@ -129,6 +129,7 @@ MODULE_DEVICE_TABLE(of, ili9163_of_match);
 
 static const struct spi_device_id ili9163_id[] = {
 	{ "nhd-1.8-128160EF", 0 },
+	{ "1.8-128160EF", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(spi, ili9163_id);


### PR DESCRIPTION
Currently enabling CONFIG_TINYDRM_ILI9163 driver - regardless of the device tree - results in the below confusing log line: SPI driver ili9163 has no spi_device_id for newhaven,1.8-128160EF

This commit fixes this false alarm by adding "1.8-128160EF" to spi_device_id table of ili9163 driver.